### PR TITLE
Add canterian charger as horse to ink story fair with the horse market scene

### DIFF
--- a/InkStories/Fair.ink
+++ b/InkStories/Fair.ink
@@ -39,16 +39,15 @@ The fair's heart beats strongest at the horse market. Proud stallions prance, th
     * [Return to the fair's heart.]->Start.choices
 
 ===BuyHorse===
-{HasEnoughGold(HorsePrice): You strike a deal with the merchant. You exchange coins for a sturdy saddle and reins. With a surge of anticipation, you mount the horse. The connection between you is immediate, the horse seems to respond to your touch with trust and eagerness. {GiveGold(-HorsePrice)} | You don't have enough gold.}
+{HasEnoughGold(HorsePrice): You strike a deal with the merchant. You exchange coins for a sturdy saddle and reins. With a surge of anticipation, you mount the horse. The connection between you is immediate, the horse seems to respond to your touch with trust and eagerness. {GiveGold(-HorsePrice)} {GiveItem("t2_empire_horse",1)} | You don't have enough gold.}
 
-~GiveItem("t2_empire_horse",1)
 * [Return to the revelry]->Start.choices
 
 ===PersuadeMerchant===
 {perform_player_skill_check("Charm",150): -> success | -> fail}
 
     =success
-    Your words work their magic, and the merchant agrees to lower the price by 25%. The merchant grumbles but respects your negotiating skills.
+    Your words work their magic, and the merchant agrees to lower the price by 50%. The merchant grumbles but respects your negotiating skills.
     ~HorsePrice = 1000
     ->HorseStalls.choices
 

--- a/InkStories/Fair.ink
+++ b/InkStories/Fair.ink
@@ -41,6 +41,7 @@ The fair's heart beats strongest at the horse market. Proud stallions prance, th
 ===BuyHorse===
 {HasEnoughGold(HorsePrice): You strike a deal with the merchant. You exchange coins for a sturdy saddle and reins. With a surge of anticipation, you mount the horse. The connection between you is immediate, the horse seems to respond to your touch with trust and eagerness. {GiveGold(-HorsePrice)} | You don't have enough gold.}
 
+~GiveItem("t2_empire_horse",1)
 * [Return to the revelry]->Start.choices
 
 ===PersuadeMerchant===
@@ -48,7 +49,7 @@ The fair's heart beats strongest at the horse market. Proud stallions prance, th
 
     =success
     Your words work their magic, and the merchant agrees to lower the price by 25%. The merchant grumbles but respects your negotiating skills.
-    ~HorsePrice = 1500
+    ~HorsePrice = 1000
     ->HorseStalls.choices
 
     =fail


### PR DESCRIPTION
- Changed persuasion check discount to 50% discount of 1000 gold
- Gave Canterian Charger for the purchase due to market value in traveling trader sell dialog